### PR TITLE
Remove External Marking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-[esbuild](https://github.com/evanw/esbuild) plugin for integrating your ESLint rules into your build process. Automatically marks node_modules as external to avoid linting them and caches results each build to drastically decrease watch build time.
+[esbuild](https://github.com/evanw/esbuild) plugin for integrating your ESLint rules into your build process. Automatically skips linting node_modules and caches the results for optimal rebuilds when watching.
 
 ## Installing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esbuild-plugin-eslinter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "esbuild plugin for integrating eslint with built in caching and node_module skipping",
   "keywords": [
     "esbuild",


### PR DESCRIPTION
- No longer mark node_modules as external, this caused more issues than I initially realized
- Find node_modules during the linting, skip linting them but still cache them
- Version bump